### PR TITLE
Bugs fixed in function predict0:

### DIFF
--- a/R/predict0.R
+++ b/R/predict0.R
@@ -232,9 +232,13 @@ predict0   <- function( mod, meig0, x0 = NULL, xgroup0 = NULL, offset0 = NULL,
   if( mod$other$model == "esf" ){
 
     if( is.null( dim( mod$r ) ) ){
-      sf_pred	<- meig0$sf[ mod$other$sf_id] %*% c( mod$r[,1] )
+      sf_pred	<- rep(0, dim(x0)[1])
     } else {
-      sf_pred	<- meig0$sf[ ,mod$other$sf_id ] %*% c( mod$r[,1] )
+      if( length(mod$r[,1]) == 1){
+        sf_pred	<- meig0$sf[ ,mod$other$sf_id ] * c( mod$r[,1] )
+      }else{
+        sf_pred	<- meig0$sf[ ,mod$other$sf_id ] %*% c( mod$r[,1] )
+      }
     }
 
     x0        <- as.matrix(x0)
@@ -262,14 +266,20 @@ predict0   <- function( mod, meig0, x0 = NULL, xgroup0 = NULL, offset0 = NULL,
       }
     }
     c_vc  <- cse_vc <- ct_vc <- cp_vc <- NULL
+    res      <- pred
+    pq_dat   <- NULL
 
 
   } else {
 
     if( is.null( dim( mod$r ) ) ){
-      sf_pred	<- meig0$sf %*% c( mod$r )
+      sf_pred	<- rep(0, dim(x0)[1])
     } else {
-      sf_pred	<- meig0$sf %*% c( mod$r[, 1 ] )
+      if( length(mod$r[,1]) == 1){
+        sf_pred	<- meig0$sf * c( mod$r[,1] )
+      }else{
+        sf_pred	<- meig0$sf %*% c( mod$r[, 1 ] )
+      }
     }
     n0        <- length( c(sf_pred) )
 

--- a/R/resf_vc.R
+++ b/R/resf_vc.R
@@ -1135,6 +1135,9 @@ resf_vc	  <- function( y, x, xconst = NULL, xgroup = NULL, weight = NULL, offset
   nsv	  <- ifelse( is.null( X1 ),1, dim( X1 )[ 2 ] + 1 )
   nev0	<- min( round( n /nsv ) - 2, length( meig$ev ))
   nev0  <- max(nev0, 3)
+    if(length( meig$ev )<nev0){
+    nev0 <- length( meig$ev )
+  }
   meig$sf	<- meig$sf[ , 1 : nev0 ]
   meig$ev	<- meig$ev[   1 : nev0 ]
 

--- a/R/resf_vc.R
+++ b/R/resf_vc.R
@@ -1135,7 +1135,7 @@ resf_vc	  <- function( y, x, xconst = NULL, xgroup = NULL, weight = NULL, offset
   nsv	  <- ifelse( is.null( X1 ),1, dim( X1 )[ 2 ] + 1 )
   nev0	<- min( round( n /nsv ) - 2, length( meig$ev ))
   nev0  <- max(nev0, 3)
-    if(length( meig$ev )<nev0){
+  if(length( meig$ev )<nev0){
     nev0 <- length( meig$ev )
   }
   meig$sf	<- meig$sf[ , 1 : nev0 ]


### PR DESCRIPTION
bug #1: If the model is esf instead of resf, the predict0 function will raise a bug "object 'res' not found". It seems that you forgot to write "res <- pred" and "pd_dat <- NULL" in the branch of "if( mod$other$model == "esf" )". In the end, the function needs return "res" and "pd_dat" and it will raise this bug.

bug #2: The case "is.null( dim( mod$r ) ) == True". If model dose not select any spatial eigenvectors, it will raise a bug. 

bug #3: The case "length(mod$r[,1]) == 1". If model only selects 1 spatial eigenvector, it will raise a bug. That is because the R language will interpret 1 sptial eigenvector as a vector structure rather than a matrix structure. "%*%" operator is not suitale for two vectors.